### PR TITLE
Carl two fellows same name

### DIFF
--- a/src/main/java/com/sfjs/conv/BusinessConverter.java
+++ b/src/main/java/com/sfjs/conv/BusinessConverter.java
@@ -63,7 +63,7 @@ public class BusinessConverter extends BaseConverter<BusinessEntity, Business> {
    */
   @Override
   public Business convertToBody(BusinessEntity src) {
-    Business dest = new Business();
+    Business dest = super.convertToBody(src);
     dest.setId(src.getId());
     dest.setBusiness(src.getName());
     dest.setEmail(src.getAccount().getEmail());

--- a/src/main/java/com/sfjs/conv/FellowConverter.java
+++ b/src/main/java/com/sfjs/conv/FellowConverter.java
@@ -51,7 +51,7 @@ public class FellowConverter extends BaseConverter<FellowEntity, Fellow> {
 
   @Override
   public Fellow convertToBody(FellowEntity src) {
-    Fellow dest = new Fellow();
+    Fellow dest = super.convertToBody(src);
     dest.setId(src.getId());
     dest.setName(src.getName());
     dest.setEmail(src.getAccount().getEmail());

--- a/src/main/java/com/sfjs/conv/FellowConverter.java
+++ b/src/main/java/com/sfjs/conv/FellowConverter.java
@@ -38,10 +38,10 @@ public class FellowConverter extends BaseConverter<FellowEntity, Fellow> {
     dest.setAccount(accountConverter.convertToEntity(account));
 
     dest.setBetaTester(src.getBetaTester());
-    if (src.isCollaborator()) {
+    if (src.getCollaborator() != null && src.getCollaborator().booleanValue()) {
       dest.setCollaborator(true);
       dest.setMessage(src.getMessage());
-      if (src.isReferralPartner()) {
+      if (src.getReferralPartner() != null && src.getReferralPartner().booleanValue()) {
         dest.setReferralPartner(true);
         dest.setReferralCode(src.getReferralCode());
       }

--- a/src/main/java/com/sfjs/dto/BaseBody.java
+++ b/src/main/java/com/sfjs/dto/BaseBody.java
@@ -1,8 +1,16 @@
 package com.sfjs.dto;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,6 +21,31 @@ public class BaseBody {
   @Getter
   @Setter
   private Long id;
+
+  @Getter
+  @Setter
+  @Version
+  private Long version;
+
+  @Getter
+  @Setter
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+  private LocalDateTime createdAt;
+
+  @Getter
+  @Setter
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+  private LocalDateTime updatedAt;
+
+  @Getter
+  @Setter
+  @Column(name = "deleted_at")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+  private LocalDateTime deletedAt;
 
   @Getter
   @Setter

--- a/src/main/java/com/sfjs/dto/Business.java
+++ b/src/main/java/com/sfjs/dto/Business.java
@@ -28,4 +28,8 @@ public class Business extends BaseBody {
   @Getter
   @Setter
   private String referral;
+
+  @Getter
+  @Setter
+  private Account account;
 }

--- a/src/main/java/com/sfjs/dto/Fellow.java
+++ b/src/main/java/com/sfjs/dto/Fellow.java
@@ -7,7 +7,7 @@ public class Fellow extends BaseBody {
 
   @Getter
   @Setter
-  private boolean collaborator;
+  private Boolean collaborator;
 
   @Getter
   @Setter
@@ -15,7 +15,7 @@ public class Fellow extends BaseBody {
 
   @Getter
   @Setter
-  private boolean referralPartner;
+  private Boolean referralPartner;
 
   @Getter
   @Setter
@@ -28,4 +28,8 @@ public class Fellow extends BaseBody {
   @Getter
   @Setter
   private Boolean betaTester;
+
+  @Getter
+  @Setter
+  private Account account;
 }

--- a/src/main/java/com/sfjs/dto/Payment.java
+++ b/src/main/java/com/sfjs/dto/Payment.java
@@ -35,6 +35,10 @@ public class Payment extends BaseBody {
 
   @Getter
   @Setter
+  private Fellow fellow;
+
+  @Getter
+  @Setter
   private String email;
 
   @Getter

--- a/src/main/java/com/sfjs/dto/Payment.java
+++ b/src/main/java/com/sfjs/dto/Payment.java
@@ -31,6 +31,10 @@ public class Payment extends BaseBody {
 
   @Getter
   @Setter
+  private Business business;
+
+  @Getter
+  @Setter
   private String fellowName;
 
   @Getter

--- a/src/main/java/com/sfjs/gql/Signup.java
+++ b/src/main/java/com/sfjs/gql/Signup.java
@@ -12,6 +12,7 @@ import com.sfjs.dto.Fellow;
 import com.sfjs.dto.Result;
 import com.sfjs.svc.BusinessService;
 import com.sfjs.svc.FellowService;
+import com.sfjs.svc.SignupService;
 
 @RestController
 @EnableWebMvc
@@ -24,6 +25,9 @@ public class Signup {
   @Autowired
   private FellowService fellowService;
 
+  @Autowired
+  private SignupService signupService;
+
   @MutationMapping(name = "signupBusiness")
   public Long signupBusiness(@Argument(name = "requestBody") Business requestBody) {
     return businessService.customSave(requestBody).getId();
@@ -31,7 +35,7 @@ public class Signup {
 
   @MutationMapping(name = "signupFellow")
   public Long signupFellow(@Argument(name = "requestBody") Fellow requestBody) {
-    return fellowService.customSave(requestBody).getId();
+    return signupService.signupFellow(requestBody).getId();
   }
 
   @Deprecated

--- a/src/main/java/com/sfjs/gql/Signup.java
+++ b/src/main/java/com/sfjs/gql/Signup.java
@@ -10,7 +10,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import com.sfjs.dto.Business;
 import com.sfjs.dto.Fellow;
 import com.sfjs.dto.Result;
-import com.sfjs.svc.BusinessService;
 import com.sfjs.svc.FellowService;
 import com.sfjs.svc.SignupService;
 
@@ -20,9 +19,6 @@ import com.sfjs.svc.SignupService;
 public class Signup {
 
   @Autowired
-  private BusinessService businessService;
-
-  @Autowired
   private FellowService fellowService;
 
   @Autowired
@@ -30,7 +26,7 @@ public class Signup {
 
   @MutationMapping(name = "signupBusiness")
   public Long signupBusiness(@Argument(name = "requestBody") Business requestBody) {
-    return businessService.customSave(requestBody).getId();
+    return signupService.signupBusiness(requestBody).getId();
   }
 
   @MutationMapping(name = "signupFellow")

--- a/src/main/java/com/sfjs/svc/CheckoutService.java
+++ b/src/main/java/com/sfjs/svc/CheckoutService.java
@@ -98,7 +98,7 @@ public class CheckoutService {
         Fellow fellow = new Fellow();
         fellow.setName(donation.getName());
         fellow.setEmail(donation.getEmail());
-        fellowService.customSave(fellow);
+        Fellow savedFellow = fellowService.customSave(fellow);
 
         // update this one field from response from helcim service
         String rawToken = response.getSecretToken();
@@ -109,7 +109,9 @@ public class CheckoutService {
         payment.setSecretToken(encryptedToken);
         // save the entity and return it
         logger.info("Save payment: " + payment);
-        return paymentService.customSave(payment);
+        Payment savedPayment = paymentService.customSave(payment);
+        savedPayment.setFellow(savedFellow);
+        return savedPayment;
       }).map(anotherPayment -> {
         anotherPayment.setCheckoutToken(response.getCheckoutToken());
         return anotherPayment;

--- a/src/main/java/com/sfjs/svc/CheckoutService.java
+++ b/src/main/java/com/sfjs/svc/CheckoutService.java
@@ -1,5 +1,6 @@
 package com.sfjs.svc;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,12 +10,17 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.security.crypto.keygen.KeyGenerators;
 import org.springframework.stereotype.Service;
 
+import com.sfjs.conv.PaymentConverter;
 import com.sfjs.dto.Business;
 import com.sfjs.dto.BusinessDonation;
 import com.sfjs.dto.Fellow;
 import com.sfjs.dto.FellowDonation;
 import com.sfjs.dto.Payment;
+import com.sfjs.entity.FellowEntity;
+import com.sfjs.entity.PaymentEntity;
 import com.sfjs.entity.PaymentStatus;
+import com.sfjs.repo.FellowRepository;
+import com.sfjs.repo.PaymentRepository;
 
 import jakarta.transaction.Transactional;
 import reactor.core.publisher.Mono;
@@ -37,6 +43,18 @@ public class CheckoutService {
 
   @Autowired
   FellowService fellowService;
+
+  @Autowired
+  SignupService signupService;
+
+  @Autowired
+  PaymentConverter paymentConverter;
+
+  @Autowired
+  FellowRepository fellowRepository;
+
+  @Autowired
+  PaymentRepository paymentRepository;
 
   Logger logger = Logger.getLogger(getClass().getName());
 
@@ -82,8 +100,14 @@ public class CheckoutService {
 
   public Mono<Payment> acceptFellowDonation(FellowDonation donation) {
 
-    logger.info("Starting initialize");
+    logger.info("Implicit fellow signup");
+    Fellow fellow = new Fellow();
+    fellow.setName(donation.getName());
+    fellow.setEmail(donation.getEmail());
+    fellow = signupService.signupFellow(fellow);
+
     Payment payment = new Payment();
+    payment.setFellow(fellow);
     payment.setAmount(donation.getAmount());
     payment.setCurrency("USD");
     payment.setEmail(donation.getEmail());
@@ -95,23 +119,24 @@ public class CheckoutService {
       // Save a field to the database
       return Mono.fromCallable(() -> {
         logger.info("fromCallable");
-        Fellow fellow = new Fellow();
-        fellow.setName(donation.getName());
-        fellow.setEmail(donation.getEmail());
-        Fellow savedFellow = fellowService.customSave(fellow);
 
         // update this one field from response from helcim service
         String rawToken = response.getSecretToken();
+        logger.info("Raw token: " + rawToken);
         String SALT = KeyGenerators.string().generateKey();
+        logger.info("Encryption SALT: " + SALT);
         payment.setSALT(SALT);
+        logger.info("Encryption password: " + PASSWORD);
         TextEncryptor encryptor = Encryptors.text(PASSWORD, SALT);
         String encryptedToken = encryptor.encrypt(rawToken);
         payment.setSecretToken(encryptedToken);
         // save the entity and return it
         logger.info("Save payment: " + payment);
-        Payment savedPayment = paymentService.customSave(payment);
-        savedPayment.setFellow(savedFellow);
-        return savedPayment;
+        PaymentEntity paymentEntity = paymentConverter.convertToEntity(payment);
+        Optional<FellowEntity> fellowEntity = fellowRepository.findById(payment.getFellow().getId());
+        paymentEntity.setFellow(fellowEntity.get());
+        PaymentEntity savedPaymentEntity = paymentRepository.save(paymentEntity);
+        return paymentConverter.convertToBody(savedPaymentEntity);
       }).map(anotherPayment -> {
         anotherPayment.setCheckoutToken(response.getCheckoutToken());
         return anotherPayment;

--- a/src/main/java/com/sfjs/svc/SignupService.java
+++ b/src/main/java/com/sfjs/svc/SignupService.java
@@ -63,15 +63,50 @@ public class SignupService {
   }
 
   private FellowEntity updateExistingFellow(Fellow requestBody, FellowEntity existingFellowEntity) {
-    existingFellowEntity.setBetaTester(requestBody.getBetaTester());
-    existingFellowEntity.setCollaborator(requestBody.isCollaborator());
-    existingFellowEntity.setMessage(requestBody.getMessage());
-    existingFellowEntity.setReferralCode(requestBody.getReferralCode());
-    existingFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    if (valueChanged(requestBody.getBetaTester(), existingFellowEntity.getBetaTester())) {
+      existingFellowEntity.setBetaTester(requestBody.getBetaTester());
+    }
+    if (valueChanged(requestBody.getCollaborator(), existingFellowEntity.isCollaborator())) {
+      existingFellowEntity.setCollaborator(requestBody.getCollaborator());
+    }
+    if (valueChanged(requestBody.getMessage(), existingFellowEntity.getMessage())) {
+      existingFellowEntity.setMessage(requestBody.getMessage());
+    }
+    if (valueChanged(requestBody.getReferralCode(), existingFellowEntity.getReferralCode())) {
+      existingFellowEntity.setReferralCode(requestBody.getReferralCode());
+    }
+    if (valueChanged(requestBody.getReferralPartner(), existingFellowEntity.isReferralPartner())) {
+      existingFellowEntity.setReferralPartner(requestBody.getReferralPartner());
+    }
     FellowEntity savedFellowEntity = fellowRepository.save(existingFellowEntity);
     return savedFellowEntity;
   }
 
+  private boolean valueChanged(String newValue, String original) {
+    if (newValue == null) return false;
+    if (original == null) return true;
+    return !newValue.contentEquals(original);
+  }
+
+  private boolean valueChanged(Boolean newValue, Boolean original) {
+    if (newValue == null) return false;
+    if (original == null) return true;
+    return newValue.booleanValue() != original.booleanValue();
+  }
+
+  /**
+   * Create a new fellow entity
+   *
+   * Because the is a new entity, we don't
+   * need to worry about changing value of
+   * existing fields.
+   * If an input field is null
+   * Then it's okay to set the entity field to null
+   *
+   * @param requestBody
+   * @param existingAccountEntity
+   * @return
+   */
   private FellowEntity createNewFellow(Fellow requestBody, AccountEntity existingAccountEntity) {
     // Create a new FellowEntity
     // Associate new fellow with existing account
@@ -79,14 +114,26 @@ public class SignupService {
     newFellowEntity.setAccount(existingAccountEntity);
     existingAccountEntity.setFellow(newFellowEntity);
     newFellowEntity.setBetaTester(requestBody.getBetaTester());
-    newFellowEntity.setCollaborator(requestBody.isCollaborator());
+    newFellowEntity.setCollaborator(requestBody.getCollaborator());
     newFellowEntity.setMessage(requestBody.getMessage());
     newFellowEntity.setReferralCode(requestBody.getReferralCode());
-    newFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    newFellowEntity.setReferralPartner(requestBody.getReferralPartner());
     FellowEntity savedFellowEntity = fellowRepository.save(newFellowEntity);
     return savedFellowEntity;
   }
 
+  /**
+   * Create a new fellow entity and account entity
+   *
+   * Because the is a new entity, we don't
+   * need to worry about changing value of
+   * existing fields.
+   * If an input field is null
+   * Then it's okay to set the entity field to null
+   *
+   * @param requestBody
+   * @return
+   */
   private FellowEntity createNewFellowAndNewAccount(Fellow requestBody) {
     // Create a new FellowEntity
     // Create a new AccountEntity
@@ -98,12 +145,12 @@ public class SignupService {
     AccountEntity savedAccountEntity = accountRepository.save(newAccountEntity);
     FellowEntity newFellowEntity = new FellowEntity();
     newFellowEntity.setAccount(savedAccountEntity);
-    newFellowEntity.setBetaTester(requestBody.getBetaTester());
-    newFellowEntity.setCollaborator(requestBody.isCollaborator());
+    newFellowEntity.setBetaTester(requestBody.getBetaTester() != null ? requestBody.getBetaTester() : false);
+    newFellowEntity.setCollaborator(requestBody.getCollaborator() != null ? requestBody.getCollaborator() : false);
     newFellowEntity.setMessage(requestBody.getMessage());
     newFellowEntity.setName(requestBody.getName());
     newFellowEntity.setReferralCode(requestBody.getReferralCode());
-    newFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    newFellowEntity.setReferralPartner(requestBody.getReferralPartner() != null ? requestBody.getReferralPartner() : false);
     FellowEntity savedFellowEntity = fellowRepository.save(newFellowEntity);
     return savedFellowEntity;
   }

--- a/src/main/java/com/sfjs/svc/SignupService.java
+++ b/src/main/java/com/sfjs/svc/SignupService.java
@@ -1,0 +1,110 @@
+package com.sfjs.svc;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.sfjs.conv.FellowConverter;
+import com.sfjs.dto.Fellow;
+import com.sfjs.entity.AccountEntity;
+import com.sfjs.entity.FellowEntity;
+import com.sfjs.entity.RoleEntity;
+import com.sfjs.repo.AccountRepository;
+import com.sfjs.repo.FellowRepository;
+import com.sfjs.repo.RoleRepository;
+
+import jakarta.transaction.Transactional;
+
+@Service
+@Transactional
+public class SignupService {
+
+  @Autowired
+  FellowConverter fellowConverter;
+
+  @Autowired
+  AccountRepository accountRepository;
+
+  @Autowired
+  RoleRepository roleRepository;
+
+  @Autowired
+  FellowRepository fellowRepository;
+
+  public Fellow signupFellow(Fellow requestBody) {
+    String email = requestBody.getEmail();
+    AccountEntity existingAccountEntity = accountRepository.findByEmail(email);
+    if (existingAccountEntity == null) {
+      // This email has never been used
+      FellowEntity savedFellowEntity = createNewFellowAndNewAccount(requestBody);
+      Fellow response = fellowConverter.convertToBody(savedFellowEntity);
+      return response;
+    } else {
+      FellowEntity existingFellowEntity = existingAccountEntity.getFellow();
+      if (existingFellowEntity == null) {
+        // No fellow
+        FellowEntity savedFellowEntity = createNewFellow(requestBody, existingAccountEntity);
+        Fellow response = fellowConverter.convertToBody(savedFellowEntity);
+        return response;
+      } else {
+        String existingFellowName = existingFellowEntity.getName();
+        if (existingFellowName != null && existingFellowName.contentEquals(requestBody.getName())) {
+          // Same fellow
+          FellowEntity savedFellowEntity = updateExistingFellow(requestBody, existingFellowEntity);
+          Fellow response = fellowConverter.convertToBody(savedFellowEntity);
+          return response;
+        } else {
+          // Different fellow
+          throw new IllegalArgumentException("Email is unavailable");
+        }
+      }
+    }
+  }
+
+  private FellowEntity updateExistingFellow(Fellow requestBody, FellowEntity existingFellowEntity) {
+    existingFellowEntity.setBetaTester(requestBody.getBetaTester());
+    existingFellowEntity.setCollaborator(requestBody.isCollaborator());
+    existingFellowEntity.setMessage(requestBody.getMessage());
+    existingFellowEntity.setReferralCode(requestBody.getReferralCode());
+    existingFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    FellowEntity savedFellowEntity = fellowRepository.save(existingFellowEntity);
+    return savedFellowEntity;
+  }
+
+  private FellowEntity createNewFellow(Fellow requestBody, AccountEntity existingAccountEntity) {
+    // Create a new FellowEntity
+    // Associate new fellow with existing account
+    FellowEntity newFellowEntity = new FellowEntity();
+    newFellowEntity.setAccount(existingAccountEntity);
+    existingAccountEntity.setFellow(newFellowEntity);
+    newFellowEntity.setBetaTester(requestBody.getBetaTester());
+    newFellowEntity.setCollaborator(requestBody.isCollaborator());
+    newFellowEntity.setMessage(requestBody.getMessage());
+    newFellowEntity.setReferralCode(requestBody.getReferralCode());
+    newFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    FellowEntity savedFellowEntity = fellowRepository.save(newFellowEntity);
+    return savedFellowEntity;
+  }
+
+  private FellowEntity createNewFellowAndNewAccount(Fellow requestBody) {
+    // Create a new FellowEntity
+    // Create a new AccountEntity
+    RoleEntity fellowRoleEntity = roleRepository.findByName("FELLOW");
+    AccountEntity newAccountEntity = new AccountEntity();
+    newAccountEntity.setEmail(requestBody.getEmail());
+    newAccountEntity.setEnabled(true);
+    newAccountEntity.setRoles(Set.of(fellowRoleEntity));
+    AccountEntity savedAccountEntity = accountRepository.save(newAccountEntity);
+    FellowEntity newFellowEntity = new FellowEntity();
+    newFellowEntity.setAccount(savedAccountEntity);
+    newFellowEntity.setBetaTester(requestBody.getBetaTester());
+    newFellowEntity.setCollaborator(requestBody.isCollaborator());
+    newFellowEntity.setMessage(requestBody.getMessage());
+    newFellowEntity.setName(requestBody.getName());
+    newFellowEntity.setReferralCode(requestBody.getReferralCode());
+    newFellowEntity.setReferralPartner(requestBody.isReferralPartner());
+    FellowEntity savedFellowEntity = fellowRepository.save(newFellowEntity);
+    return savedFellowEntity;
+  }
+}


### PR DESCRIPTION
This is for when two people sign up or donate, and they have the same name but different email addresses.

The current behavior was to silently change the email address.  This is a bug and we were losing information.
The payments would be silently reassigned to the new email address.

The new behavior will be to create a new fellow and associate it with a new account with a different email address.
The payment will be associated with different fellow objects and therefore different accounts/emails.